### PR TITLE
improve some minor bags

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,5 +1,11 @@
                         <div class="ampstart-card abe-sample-card flex flex-column flex-auto p1 mb1">
-                            <h3 class="mb1">{{ .Title }}<i class=""></i></h3>
+                            <h3 class="mb1">{{ .Title }}<i class=""></i>
+                                <div style="font:italic normal bold 60% 'メイリオ',sans-serif;">{{ .Date.Format "Mon, Jan 2, 2006" }}</div>
+                                <div style="font-size: 70%">
+                                    {{ range .Params.categories }}
+                                    <a href="{{ "/categories/" | relLangURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}
+                                </div>
+                            </h3>
                             {{if gt (len .Summary) 200}}
                                 <p class="mb1">{{slicestr .Summary 3 200 }}</p>
                             {{else}}

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -7,7 +7,7 @@
                                 </div>
                             </h3>
                             {{if gt (len .Summary) 200}}
-                                <p class="mb1">{{slicestr .Summary 3 200 }}</p>
+                                <p class="mb1">{{slicestr .Summary 0 200 }}</p>
                             {{else}}
                                 <p class="mb1">{{ .Summary }}</p>
                             {{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -85,7 +85,7 @@
 <body>
     <!-- Start Navbar -->
     <header class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
-        <div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger md-hide lg-hide pr2">☰</div>
+        <!--<div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger md-hide lg-hide pr2">☰</div>-->
         <a href="/" class="my0 mx-auto">
             {{.Site.Title}}
             <!-- <amp-img src="/img/logo.svg" width="150" height="40" class="" layout="fixed" alt="{{ .Title }}"></amp-img> -->


### PR DESCRIPTION
いくつか表示方法を修正しました。
・スマホ画面での左上の☰のボタンを非表示
・ブログ一覧に名前、日付の表示
・サマリの本文が3文字消えている問題の改善